### PR TITLE
Revert "use host and user credentials for db connections"

### DIFF
--- a/lib/ferry/utilities.rb
+++ b/lib/ferry/utilities.rb
@@ -10,11 +10,7 @@ module Ferry
       db_type = db_config[environment]["adapter"]
 
       if ['sqlite3', 'postgresql', 'mysql2'].include?(db_type)
-        ActiveRecord::Base.establish_connection(adapter: db_type, 
-                                                database: db_config[environment]['database'], 
-                                                username: db_config[environment]['username'], 
-                                                password: db_config[environment]['password'],
-                                                host: db_config[environment]['host'])
+        ActiveRecord::Base.establish_connection(adapter: db_type, database: db_config[environment]['database'])
         puts "operating with "+db_type
         return db_type
       else

--- a/spec/config/database.yml
+++ b/spec/config/database.yml
@@ -15,13 +15,6 @@ postgresql: &postgresql
   adapter: postgresql
   min_messages: warning
 
-postgresql_system_user_name: &postgresql_system_user_name
-  <<: *default
-  username: 
-  password: ' '
-  adapter: postgresql
-  min_messages: warning
-
 sqlite3: &sqlite3
   adapter: sqlite3
   database: test.db

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,10 +21,6 @@ def connect(adapter)
   test_dir = Pathname.new File.dirname(__FILE__)
   ENV["RAILS_ENV"] = adapter || "test"
   db = YAML.load_file(test_dir.join("config/database.yml"))[adapter]
-  ActiveRecord::Base.establish_connection(adapter: adapter, 
-                                          database: db['database'], 
-                                          username: db['username'], 
-                                          password: db['password'],
-                                          host: db['host'])
+  ActiveRecord::Base.establish_connection(:adapter => adapter, :database => db["database"])
   load File.dirname(__FILE__) + '/support/schema.rb'
 end

--- a/spec/tests/utilities_tests.rb
+++ b/spec/tests/utilities_tests.rb
@@ -15,11 +15,6 @@ describe("utility functions") do
         expect(ActiveRecord::Base.connection.adapter_name).to eql('PostgreSQL')
       end
 
-      it "#postgresql fails if system user name is not role in PostgreSQL" do
-        expect{utils.db_connect("postgresql_system_user_name")}.not_to raise_error
-        expect{ActiveRecord::Base.connection.adapter_name}.to raise_error
-      end
-
       it "#mysql2" do
         expect{utils.db_connect("mysql2")}.not_to raise_error
         expect(ActiveRecord::Base.connection.adapter_name).to eql('Mysql2')


### PR DESCRIPTION
Reverts cmu-is-projects/ferry#57

Found that this broke a couple tests - will be looking into how to incorporate this PR so that they don't break again

```
Finished in 4.71 seconds (files took 0.62901 seconds to load)
32 examples, 8 failures

Failed examples:

rspec ./tests/utilities_tests.rb:18 # utility functions #db_connect #postgresql fails if system user name is not role in PostgreSQL
rspec ./tests/exporter_tests.rb:67 # export functionality #export postgresql db to_csv call should create a populated csv file
rspec ./tests/exporter_tests.rb:78 # export functionality #export postgresql db to_csv should error if specified table does not exist
rspec ./tests/exporter_tests.rb:83 # export functionality #export postgresql db to_yaml call should create a populated yaml file
rspec ./tests/exporter_tests.rb:95 # export functionality #export postgresql db to_yaml should error if specified table does not exist
rspec ./tests/importer_tests.rb:97 # #import postgresql db should import a valid csv into ActiveRecord
rspec ./tests/importer_tests.rb:119 # #import mass insert tests (postgresql) should be able to import >500 records
rspec ./tests/importer_tests.rb:129 # #import mass insert tests (postgresql) should not commit import if any record errors
```